### PR TITLE
feat(template): project-owned chown-paths for named-volume ownership

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -9,6 +9,9 @@ on:
       - template/Dockerfile
       - template/docker-compose.yml
       - template/post-create.py
+      - template/aic-firewall
+      - template/aic-chown-volumes
+      - template/aic-lock-gitconfig
       - template/hooks/**
       - .github/workflows/rebuild.yml
   pull_request:
@@ -16,6 +19,9 @@ on:
       - template/Dockerfile
       - template/docker-compose.yml
       - template/post-create.py
+      - template/aic-firewall
+      - template/aic-chown-volumes
+      - template/aic-lock-gitconfig
       - template/hooks/**
   workflow_dispatch:
 
@@ -111,6 +117,29 @@ jobs:
               exit 1
             fi
             echo "OK: arbitrary sudo chown is denied"
+          '
+
+      - name: Smoke test - chown-paths allowlist is enforced
+        working-directory: /tmp/proj
+        run: |
+          # chown-paths is RO-mounted + PreToolUse-blocked, so an in-container
+          # tool can't add entries. But a forbidden entry (e.g. a careless
+          # host-side edit) must still be refused fail-closed without touching
+          # the target. We write it host-side; the live RO bind mount reflects
+          # it inside the container.
+          trap 'rm -rf .devcontainer/chown-paths .venv-smoke' EXIT
+          printf '/home/vscode/.gitconfig.local\n' > .devcontainer/chown-paths
+          devcontainer exec --workspace-folder . bash -lc '
+            sudo -n /usr/local/bin/aic-chown-volumes && { echo "FAIL: accepted out-of-allowlist path"; exit 1; }
+            owner=$(stat -c "%U" /home/vscode/.gitconfig.local)
+            [ "$owner" = "root" ] || { echo "FAIL: gitconfig.local now owned by $owner"; exit 1; }
+            echo "OK: forbidden chown-paths entry refused; gitconfig.local still root-owned"
+          '
+          printf '/workspace/.venv-smoke\n' > .devcontainer/chown-paths
+          devcontainer exec --workspace-folder . bash -lc '
+            mkdir -p /workspace/.venv-smoke
+            sudo -n /usr/local/bin/aic-chown-volumes || { echo "FAIL: rejected a valid /workspace path"; exit 1; }
+            echo "OK: valid /workspace chown-paths entry accepted"
           '
 
       - name: Smoke test - gitconfig.local is root-owned 0444

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,29 @@ jobs:
             echo "OK: arbitrary sudo chown is denied"
           '
 
+      - name: Smoke test - chown-paths allowlist is enforced
+        working-directory: /tmp/proj
+        run: |
+          # chown-paths is RO-mounted + PreToolUse-blocked, so an in-container
+          # tool can't add entries. But a forbidden entry (e.g. a careless
+          # host-side edit) must still be refused fail-closed without touching
+          # the target. We write it host-side; the live RO bind mount reflects
+          # it inside the container.
+          trap 'rm -rf .devcontainer/chown-paths .venv-smoke' EXIT
+          printf '/home/vscode/.gitconfig.local\n' > .devcontainer/chown-paths
+          devcontainer exec --workspace-folder . bash -lc '
+            sudo -n /usr/local/bin/aic-chown-volumes && { echo "FAIL: accepted out-of-allowlist path"; exit 1; }
+            owner=$(stat -c "%U" /home/vscode/.gitconfig.local)
+            [ "$owner" = "root" ] || { echo "FAIL: gitconfig.local now owned by $owner"; exit 1; }
+            echo "OK: forbidden chown-paths entry refused; gitconfig.local still root-owned"
+          '
+          printf '/workspace/.venv-smoke\n' > .devcontainer/chown-paths
+          devcontainer exec --workspace-folder . bash -lc '
+            mkdir -p /workspace/.venv-smoke
+            sudo -n /usr/local/bin/aic-chown-volumes || { echo "FAIL: rejected a valid /workspace path"; exit 1; }
+            echo "OK: valid /workspace chown-paths entry accepted"
+          '
+
       - name: Smoke test - gitconfig.local is root-owned 0444
         working-directory: /tmp/proj
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wholesale on every `init`/`sync`; only `AIC_TOOLS` / `AIC_SHELL` survive (they
 are re-derived from the old file and re-injected by `patch_devcontainer_json`).
 So users must **not** hand-edit those two files — per-project tweaks go in
 project-owned files that `apply_template()` never touches: `Dockerfile.project`,
-`firewall-allowlist`, and `docker-compose.override.yml`.
+`firewall-allowlist`, `chown-paths`, and `docker-compose.override.yml`.
 
 The override is the sync-safe home for anything that would otherwise live in
 `containerEnv` or the compose service (env, `extra_hosts`, mounts, a
@@ -81,6 +81,17 @@ Keep the template's array single-entry — do not pre-list the override there, o
 `devcontainer up` fails on projects that don't have the file (a missing
 `dockerComposeFile` entry is a hard error). The wiring is opt-in by file
 presence, mirroring how `firewall-allowlist` is read only if present.
+
+`chown-paths` is the companion to override-declared **named volumes**. Docker
+inits a fresh named volume `root:root` and `updateRemoteUserUID` doesn't touch
+the daemon's init UID, so a `myproject-venv:/workspace/.venv` mount lands
+unwritable by `vscode`. A project lists such mountpoints (one per line) in
+`.devcontainer/chown-paths`; `post-create.py`'s `fix_volume_ownership()` then
+re-owns them via `aic-chown-volumes` on container creation. Same opt-in-by-
+presence, read-only-inside-container, survives-sync contract as
+`firewall-allowlist`. **The prefix allowlist (`/workspace/`,
+`/home/vscode/.cache/`) is the security boundary — see "Security stance"
+before widening it.**
 
 ## Releasing
 
@@ -173,7 +184,15 @@ should be reviewed for security regressions:
   sensitive paths. Loosening the deny list weakens the model.
 - `template/aic-chown-volumes`, `template/aic-lock-gitconfig` — the only
   scripts allowed via `NOPASSWD` sudo. Touching them changes the privileged
-  surface.
+  surface. `aic-chown-volumes` reads project-supplied targets from
+  `.devcontainer/chown-paths`, **never from argv** — that's what stops the
+  `NOPASSWD` grant from becoming an arbitrary `sudo aic-chown-volumes
+  /etc/sudoers.d`. The hardcoded prefix allowlist (`/workspace/`,
+  `/home/vscode/.cache/`) plus `-h`/non-traversing `-R` is the boundary;
+  widening it to broader `$HOME` would expose `~/.gitconfig.local` (the
+  root-locked gitconfig) and is a load-bearing decision. The "scoped sudo
+  cannot chown arbitrary paths" smoke test guards this — extend it, don't
+  weaken it.
 - `.github/workflows/*.yml` — CI secrets (`NPM_TOKEN`, GHCR via
   `GITHUB_TOKEN`). The `publish` jobs only run on push/schedule/dispatch,
   never on `pull_request`, to keep fork PRs from triggering publishes.

--- a/README.md
+++ b/README.md
@@ -263,6 +263,37 @@ Run `aic rebuild` after editing. Verify the wiring landed with `grep dockerCompo
 
 > The same file is also the sync-safe place to point at a [`Dockerfile.project`](#b-persistent-in-a-project-dockerfile): put the `build:` block in the override instead of editing `docker-compose.yml`. Compose merges `build:` onto the base service; `aic rebuild` refreshes the base image, then rebuilds your layer on top.
 
+### Persisting a named volume (and fixing its ownership)
+
+A common override is a **named volume** over a build artifact you don't want on the bind-mounted workspace — a Python `.venv`, `node_modules`, a language cache — so it persists across rebuilds and dodges the macOS bind-mount performance hit:
+
+```yaml
+# .devcontainer/docker-compose.override.yml
+services:
+  devcontainer:
+    volumes:
+      - myproject-venv:/workspace/.venv
+      - myproject-uv-cache:/home/vscode/.cache/uv
+volumes:
+  myproject-venv:
+  myproject-uv-cache:
+```
+
+There's a catch: Docker initializes a **fresh named volume as `root:root`**, and `updateRemoteUserUID` only remaps the user *inside* the container, not the daemon's volume-init UID. So `vscode` can't write into the mount and your `uv` / `npm` install fails. (You can't fix this with `sudo chown` from inside — in-container sudo is scoped to three aic helper scripts, not general `chown`.)
+
+The sync-safe fix is a project-owned **`.devcontainer/chown-paths`** — one mountpoint per line; `aic-chown-volumes` re-owns each to `vscode` on container creation:
+
+```
+# .devcontainer/chown-paths — re-owned to vscode on container create.
+# Only paths under /workspace/ or /home/vscode/.cache/ are honored.
+/workspace/.venv
+/home/vscode/.cache/uv
+```
+
+Like `firewall-allowlist`, this file is opt-in (read only if present), never touched by `aic sync`, and read-only inside the container (an in-container tool can't edit it). The prefix allowlist is a hard security boundary baked into the image — paths outside `/workspace/` and `/home/vscode/.cache/` are refused, so the re-own can't be pointed at sudoers, the hooks, or `~/.gitconfig.local`. Keep tool caches under `~/.cache/` (e.g. `CARGO_HOME=/home/vscode/.cache/cargo` in the override) so they fall inside the allowlist.
+
+> Already created the volume root-owned from an earlier run? `aic-chown-volumes` fixes it on the next `aic rebuild`. If it was populated by a partial install, `docker volume rm <name>` once and let it re-init clean.
+
 ## Updating AI tools
 
 ```bash
@@ -275,7 +306,7 @@ The pull-mode compose file pins `ghcr.io/stefanoginella/aicontainer:vX.Y.Z` to w
 
 `:vX.Y.Z` tags are immutable once published — they capture the exact image built at release time. CI separately rebuilds and pushes a floating `ghcr.io/stefanoginella/aicontainer:latest` on a weekly schedule and on every template change merged to main, for users who prefer base-layer freshness over reproducibility; that tag isn't referenced by default, but you can opt in by editing `.devcontainer/docker-compose.yml`. In `--build` mode `aic rebuild` does a no-cache local build that re-runs the `claude` and `codex` installers.
 
-The 2 files (pull mode) or full set (build mode) under `.devcontainer/` are not refreshed by `aic rebuild` on their own — they're created once by `aic init`. If a new template version changes them (e.g. a docker-compose mount), run `aic sync` to re-copy from the installed template into `./.devcontainer/`, then `aic rebuild`. `aic sync` auto-detects pull vs. build mode, preserves the project's `AIC_TOOLS` and `AIC_SHELL` selections (pass `--with` / `--shell` to change them), and leaves project-owned files (`Dockerfile.project`, `firewall-allowlist`, `docker-compose.override.yml`) untouched — re-wiring an existing [`docker-compose.override.yml`](#per-project-overrides-that-survive-aic-sync) into `dockerComposeFile` so per-project compose tweaks survive the sync.
+The 2 files (pull mode) or full set (build mode) under `.devcontainer/` are not refreshed by `aic rebuild` on their own — they're created once by `aic init`. If a new template version changes them (e.g. a docker-compose mount), run `aic sync` to re-copy from the installed template into `./.devcontainer/`, then `aic rebuild`. `aic sync` auto-detects pull vs. build mode, preserves the project's `AIC_TOOLS` and `AIC_SHELL` selections (pass `--with` / `--shell` to change them), and leaves project-owned files (`Dockerfile.project`, `firewall-allowlist`, `chown-paths`, `docker-compose.override.yml`) untouched — re-wiring an existing [`docker-compose.override.yml`](#per-project-overrides-that-survive-aic-sync) into `dockerComposeFile` so per-project compose tweaks survive the sync.
 
 ## Multi-project model
 

--- a/aic
+++ b/aic
@@ -447,7 +447,7 @@ cmd_sync () {
   patch_devcontainer_json ".devcontainer/devcontainer.json" "$tools" "$shell"
   echo "aic: synced $mode-mode template → .devcontainer/ (tools: $tools, shell: $shell)"
   echo "aic: review with 'git diff -- .devcontainer/', then 'aic rebuild'"
-  echo "aic: project-owned files (Dockerfile.project, firewall-allowlist, docker-compose.override.yml) are untouched"
+  echo "aic: project-owned files (Dockerfile.project, firewall-allowlist, chown-paths, docker-compose.override.yml) are untouched"
   [ -f .devcontainer/docker-compose.override.yml ] && \
     echo "aic: wired docker-compose.override.yml into dockerComposeFile"
 }
@@ -559,7 +559,8 @@ Usage:
                        --pull or --build to force one. Existing AIC_TOOLS /
                        AIC_SHELL selections are preserved unless overridden.
                        Project-owned files (Dockerfile.project, firewall-
-                       allowlist, docker-compose.override.yml) are untouched;
+                       allowlist, chown-paths, docker-compose.override.yml)
+                       are untouched;
                        an existing docker-compose.override.yml is auto-wired
                        into dockerComposeFile so per-project compose tweaks
                        (env, extra_hosts, build) survive the sync. Useful after

--- a/template/aic-chown-volumes
+++ b/template/aic-chown-volumes
@@ -2,10 +2,24 @@
 # =============================================================================
 # aic-chown-volumes — re-own aicontainer's persistent volume mount points
 # =============================================================================
-# Called via scoped sudo from post-create.py on first container creation
-# (named volumes come up root-owned). Targets are hardcoded, and -h prevents
-# a symlink the AI may have planted in a persisted volume from redirecting
-# chown to /etc/sudoers.d/vscode or similar.
+# Called via scoped sudo from post-create.py on container creation (named
+# volumes come up root-owned). Targets come from two sources, both *outside*
+# argv:
+#
+#   1. The hardcoded list below — aic's own auth/session/history volumes.
+#   2. Optional project-declared mountpoints, one path per line in
+#      /workspace/.devcontainer/chown-paths (see README "Persisting a named
+#      volume"). Only paths under /workspace/ or /home/vscode/.cache/ are
+#      honored.
+#
+# Targets are NEVER read from this script's arguments. The scoped sudoers entry
+# lets vscode *invoke* the script, but because the policy lives in hardcoded
+# paths + a read-only, PreToolUse-blocked file (not argv), running
+# `sudo aic-chown-volumes /etc/sudoers.d` cannot redirect the chown. Combined
+# with -h (never dereference a final-component symlink) and the prefix
+# allowlist below — which excludes /etc, /etc/aic/hooks, and
+# ~/.gitconfig.local — the NOPASSWD grant cannot be turned into a privilege
+# escalation.
 #
 # Replaces the previous `NOPASSWD: /usr/bin/chown` sudoers entry, which let
 # any in-container process chown arbitrary paths and escalate to root.
@@ -17,6 +31,13 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
+chown_safe() {
+  # -h: act on a symlink itself, never its referent. -R without -H/-L is -P
+  # under GNU coreutils, so recursion does not traverse symlinks — a symlink
+  # planted in a persisted volume cannot redirect chown to /etc/sudoers.d etc.
+  chown -h -R vscode:vscode "$1"
+}
+
 for d in /home/vscode/.shell-history \
          /home/vscode/.config/aic-auth \
          /home/vscode/.claude-sessions \
@@ -24,5 +45,33 @@ for d in /home/vscode/.shell-history \
          /home/vscode/.codex \
          /home/vscode/.config/gh \
          /home/vscode/.config/npm; do
-  [ -d "$d" ] && chown -h -R vscode:vscode "$d"
+  [ -d "$d" ] && chown_safe "$d"
 done
+
+# Project-declared volume mountpoints. Opt-in: read only if the project
+# created the file, mirroring firewall-allowlist. The prefix allowlist is the
+# security boundary — anything outside /workspace/ and /home/vscode/.cache/
+# (sudoers, /etc/aic/hooks, ~/.gitconfig.local, the rest of $HOME) is refused,
+# fail-closed, even though the file is itself read-only inside the container.
+EXTRA_FILE="/workspace/.devcontainer/chown-paths"
+if [ -f "$EXTRA_FILE" ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    p="${line%%#*}"                              # strip trailing comment
+    p="${p#"${p%%[![:space:]]*}"}"               # ltrim
+    p="${p%"${p##*[![:space:]]}"}"               # rtrim
+    [ -n "$p" ] || continue
+    case "/$p/" in
+      */../*)
+        echo "aic-chown-volumes: refusing path with a '..' component: $p" >&2
+        exit 1 ;;
+    esac
+    case "$p" in
+      /workspace/?*|/home/vscode/.cache/?*)
+        [ -e "$p" ] && chown_safe "$p" ;;
+      *)
+        echo "aic-chown-volumes: refusing out-of-allowlist path: $p" >&2
+        echo "  (only /workspace/* and /home/vscode/.cache/* are allowed)" >&2
+        exit 1 ;;
+    esac
+  done < "$EXTRA_FILE"
+fi

--- a/template/post-create.py
+++ b/template/post-create.py
@@ -36,6 +36,13 @@ HOST_GITCONFIG = HOME / ".gitconfig"             # bind-mounted RO from host
 HOST_SEED_CLAUDE = Path("/host-seed/claude")     # bind-mounted RO file/dir
 HOST_SEED_CODEX = Path("/host-seed/codex")       # bind-mounted RO file
 
+# Optional project-declared volume mountpoints to re-own, one path per line in
+# .devcontainer/chown-paths. The prefix allowlist mirrors (advisory-only) the
+# authoritative check in aic-chown-volumes; the root script re-validates, so a
+# bad entry that slips past here is still refused where it matters.
+PROJECT_CHOWN_FILE = Path("/workspace/.devcontainer/chown-paths")
+CHOWN_ALLOWED_PREFIXES = ("/workspace/", "/home/vscode/.cache/")
+
 # Per-project tool selection. Set by `aic init`/`aic sync` as
 # containerEnv.AIC_TOOLS in .devcontainer/devcontainer.json. Empty/unset
 # defaults to both tools (preserves behavior for projects pinned before the
@@ -92,11 +99,30 @@ def log(msg: str) -> None:
     print(f"[post-create] {msg}", file=sys.stderr)
 
 
+def _project_chown_paths() -> list[Path]:
+    """Parse .devcontainer/chown-paths (project-owned, RO-mounted) into the
+    list of extra volume mountpoints to re-own. Entries outside the prefix
+    allowlist are skipped here with a warning; aic-chown-volumes re-validates
+    them as the authoritative (root-side) gate, so this is advisory only."""
+    if not PROJECT_CHOWN_FILE.is_file():
+        return []
+    paths: list[Path] = []
+    for raw in PROJECT_CHOWN_FILE.read_text().splitlines():
+        entry = raw.split("#", 1)[0].strip()
+        if not entry:
+            continue
+        if ".." in entry.split("/") or not entry.startswith(CHOWN_ALLOWED_PREFIXES):
+            log(f"warning: ignoring out-of-allowlist chown-paths entry: {entry!r}")
+            continue
+        paths.append(Path(entry))
+    return paths
+
+
 def fix_volume_ownership() -> None:
     """Named volumes mount as root:root on first creation. Re-own them via
-    the scoped /usr/local/bin/aic-chown-volumes wrapper (hardcoded targets,
-    -h to block symlink-following) so the sudo grant cannot be turned into
-    an arbitrary-path chown."""
+    the scoped /usr/local/bin/aic-chown-volumes wrapper (fixed targets + the
+    project chown-paths allowlist, -h to block symlink-following) so the sudo
+    grant cannot be turned into an arbitrary-path chown."""
     uid = os.getuid()
     needs_chown = False
     for path in (
@@ -110,6 +136,13 @@ def fix_volume_ownership() -> None:
     ):
         path.mkdir(parents=True, exist_ok=True)
         if path.stat().st_uid != uid:
+            needs_chown = True
+    # Project-declared mountpoints: don't mkdir (they're volume mounts that
+    # exist iff the volume is attached); only flag a chown when one is present
+    # and still root-owned — e.g. a rebuild where aic's own volumes are already
+    # correct but a freshly-created project volume isn't.
+    for path in _project_chown_paths():
+        if path.exists() and path.stat().st_uid != uid:
             needs_chown = True
     if needs_chown:
         try:


### PR DESCRIPTION
## What

Adds a project-owned `.devcontainer/chown-paths` file (mirrors `firewall-allowlist`) so projects can have aicontainer re-own their override-declared **named volumes** to `vscode` on container creation.

### Why

Docker inits a fresh named volume `root:root`, and `updateRemoteUserUID` only remaps the in-container user, not the daemon's volume-init UID. So a project's `myproject-venv:/workspace/.venv` mount lands unwritable by `vscode`. In-container sudo is scoped to three wrappers (no general `chown`), and `devcontainer.json` is regenerated by `aic sync` (so a `postStartCommand` there wouldn't survive). `chown-paths` is the sync-safe, project-owned fix.

## How it stays safe

`aic-chown-volumes` is one of only three `NOPASSWD` wrappers, so the design avoids turning the grant into arbitrary chown:

- **Targets come from the RO, PreToolUse-blocked file — never argv.** `sudo aic-chown-volumes /etc/sudoers.d` is a no-op.
- **Hard prefix allowlist** (`/workspace/`, `/home/vscode/.cache/`) excludes sudoers, `/etc/aic/hooks`, and `~/.gitconfig.local`. Out-of-allowlist entries fail closed.
- `-h` + non-traversing `-R` block symlink redirection.

## Changes

- `template/aic-chown-volumes` — read + validate `chown-paths`.
- `template/post-create.py` — `fix_volume_ownership()` stat-checks the entries too, so a rebuild re-owns a fresh project volume even when aic's own volumes are already correct.
- Smoke test in both workflows: forbidden entry refused (target stays root-owned), valid `/workspace` entry accepted.
- `rebuild.yml` paths now include the `aic-*` helper scripts (baked into the image but previously missing from the trigger).
- Docs: README "Persisting a named volume", AGENTS.md, `aic` CLI messages.

## Test

Local: bash/python syntax checks, path-allowlist battery (allows `/workspace/foo..bar`, rejects `../`, `~/.gitconfig.local`, bare prefixes), file-parser edge cases, YAML validation. CI smoke covers the in-container behavior against a locally-built image.