### PR TITLE
feat(signing): `aic signing` for sandbox-only commit signing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,6 +22,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # ---------------------------------------------------------------------------
 # System packages (base image already ships git, curl, sudo, etc.)
 # ---------------------------------------------------------------------------
+# openssh-client provides ssh-keygen, which Git invokes for SSH commit signing
+# (gpg.format=ssh: sign via `ssh-keygen -Y sign`, verify via `-Y verify`) and
+# which `aic signing` uses to mint the sandbox signing key. Required even just
+# to *sign*, not only to generate — so make the dependency explicit here rather
+# than relying on the base image happening to include it.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       fd-find \
       ripgrep \
@@ -38,6 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       iproute2 \
       iptables \
       ipset \
+      openssh-client \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # git-delta

--- a/.devcontainer/post-create.py
+++ b/.devcontainer/post-create.py
@@ -142,7 +142,6 @@ def fix_volume_ownership() -> None:
     for path in (
         HOME / ".shell-history",
         AUTH,
-        SIGNING,
         SESSIONS,
         HOME / ".claude",
         HOME / ".codex",
@@ -152,6 +151,12 @@ def fix_volume_ownership() -> None:
         path.mkdir(parents=True, exist_ok=True)
         if path.stat().st_uid != uid:
             needs_chown = True
+    # NOTE: the signing dir (AUTH/signing) is intentionally NOT created here.
+    # On first creation AUTH is a root-owned named volume, and mkdir-ing a NEW
+    # subdir as vscode before the chown below would EACCES (the other entries
+    # are pre-existing Docker mountpoints, so their mkdir is a harmless no-op).
+    # `aic signing` creates signing/ as vscode once the volume is writable, and
+    # aic-chown-volumes re-owns AUTH recursively, so it stays vscode-owned.
     # Project-declared mountpoints: don't mkdir (they're volume mounts that
     # exist iff the volume is attached); only flag a chown when one is present
     # and still root-owned — e.g. a rebuild where aic's own volumes are already

--- a/.devcontainer/post-create.py
+++ b/.devcontainer/post-create.py
@@ -33,6 +33,15 @@ HOME = Path.home()
 AUTH = HOME / ".config" / "aic-auth"            # global volume
 SESSIONS = HOME / ".claude-sessions"             # per-project volume
 HOST_GITCONFIG = HOME / ".gitconfig"             # bind-mounted RO from host
+
+# Sandbox commit-signing material, provisioned by `aic signing` and persisted
+# in the aic-auth-global volume (so the pubkey is registered on GitHub once and
+# survives rebuilds). The host's own signing key is never forwarded; see
+# setup_commit_signing().
+SIGNING = AUTH / "signing"
+SIGNING_KEY = SIGNING / "id_ed25519"             # private key (0600, vscode-owned)
+SIGNING_MODE = SIGNING / "mode"                  # "auto" | "byok" | "disabled"
+SIGNING_ALLOWED = SIGNING / "allowed_signers"    # for in-container verification
 HOST_SEED_CLAUDE = Path("/host-seed/claude")     # bind-mounted RO file/dir
 HOST_SEED_CODEX = Path("/host-seed/codex")       # bind-mounted RO file
 
@@ -133,6 +142,7 @@ def fix_volume_ownership() -> None:
     for path in (
         HOME / ".shell-history",
         AUTH,
+        SIGNING,
         SESSIONS,
         HOME / ".claude",
         HOME / ".codex",
@@ -389,6 +399,93 @@ def setup_codex() -> None:
     link(SESSIONS / "codex-history.jsonl", codex_dir / "history.jsonl")
 
 
+def _host_git_config(key: str) -> str:
+    """Read a single value straight from the read-only host ~/.gitconfig
+    (not the effective config, so we see the host's intent regardless of our
+    own override ordering). Empty string if unset or git is unavailable."""
+    try:
+        r = subprocess.run(
+            ["git", "config", "--file", str(HOST_GITCONFIG), "--get", key],
+            capture_output=True, text=True,
+        )
+        return r.stdout.strip() if r.returncode == 0 else ""
+    except FileNotFoundError:
+        return ""
+
+
+def setup_commit_signing() -> str:
+    """Return the container-local commit-signing config to append to
+    ~/.gitconfig.local *after* the host [include] (so it overrides the host's
+    signing settings — inside the sandbox only; the host gitconfig is mounted
+    read-only and never touched).
+
+    Why this exists: the host's signing key never enters the container (~/.ssh
+    and the SSH agent are deliberately not forwarded), so a host configured for
+    SSH/GPG commit signing would otherwise fail every `git commit` here with
+    "Couldn't find key in agent". Instead `aic signing` provisions a
+    sandbox-only ed25519 signing key in the aic-auth-global volume; this wires
+    it up when present. Mode (set by `aic signing`, persisted in the volume):
+
+      - key present (auto/byok) -> sign with it via gpg.format=ssh, regardless
+        of whether the host signed with SSH or GPG (the switch is container-only).
+      - mode 'disabled'         -> signing off in the sandbox (quiet).
+      - host signs, but no key  -> signing off + LOUD notice (the safe default,
+        so commits don't fail cryptically before a key is set up).
+      - host doesn't sign       -> nothing.
+
+    Takes effect on container (re)create only: ~/.gitconfig.local is rewritten
+    fresh each creation and then root-locked, so a mode change via `aic signing`
+    lands on the next rebuild — no live edit of the locked file is needed (and
+    no privileged unlock primitive, which a compromised session could abuse)."""
+    off = "[commit]\n    gpgsign = false\n[tag]\n    gpgsign = false\n"
+    mode = SIGNING_MODE.read_text().strip() if SIGNING_MODE.is_file() else ""
+
+    if mode == "disabled":
+        log("commit signing: disabled in sandbox (your choice via 'aic signing')")
+        return off
+
+    if SIGNING_KEY.is_file():
+        # ssh-keygen refuses keys with loose perms; we own the file (it's
+        # created as vscode by `aic signing`), so tighten it each create.
+        try:
+            SIGNING_KEY.chmod(0o600)
+        except OSError as e:
+            log(f"warning: could not chmod signing key: {e}")
+        block = (
+            "[gpg]\n    format = ssh\n"
+            f"[user]\n    signingkey = {SIGNING_KEY}\n"
+            "[commit]\n    gpgsign = true\n"
+        )
+        # Also wire verification so in-container `git log --show-signature`
+        # works instead of erroring on the host's allowedSignersFile (a
+        # host-only path). Best-effort; signing itself doesn't need it.
+        email = _host_git_config("user.email")
+        pub = SIGNING_KEY.with_suffix(".pub")
+        if email and pub.is_file():
+            try:
+                SIGNING_ALLOWED.write_text(f"{email} {pub.read_text().strip()}\n")
+                block += f'[gpg "ssh"]\n    allowedSignersFile = {SIGNING_ALLOWED}\n'
+            except OSError as e:
+                log(f"warning: could not write allowed_signers: {e}")
+        fp = ""
+        try:
+            r = subprocess.run(["ssh-keygen", "-lf", str(pub)], capture_output=True, text=True)
+            if r.returncode == 0:
+                fp = r.stdout.split()[1]
+        except (FileNotFoundError, IndexError):
+            pass
+        log(f"commit signing: sandbox ssh key{(' ' + fp) if fp else ''} (mode={mode or 'auto'})")
+        return block
+
+    if _host_git_config("commit.gpgsign").lower() == "true":
+        log("commit signing: host enables it but no sandbox key — commits are "
+            "UNSIGNED here. Run 'aic signing' to provision a sandbox signing key "
+            "(or 'aic signing disable' to silence this).")
+        return off
+
+    return ""
+
+
 def setup_gitconfig() -> None:
     """Write ~/.gitconfig.local (pointed at by GIT_CONFIG_GLOBAL in
     devcontainer.json). Includes the read-only host gitconfig and adds
@@ -406,6 +503,10 @@ def setup_gitconfig() -> None:
         # (file is root:root 0444). Skip the rewrite — we'd hit EACCES and the
         # contents are stable anyway.
         return
+    # Commit-signing config goes LAST so it overrides the host [include] above
+    # (git takes the last value for single-valued keys; the include is inlined
+    # at the top, our block is appended at the bottom).
+    signing = setup_commit_signing()
     local.write_text(
         f"# aicontainer container-local git config\n"
         f"[include]\n    path = {HOST_GITCONFIG}\n"
@@ -416,6 +517,7 @@ def setup_gitconfig() -> None:
         f"[delta]\n    navigate = true\n    line-numbers = true\n"
         f"[merge]\n    conflictstyle = diff3\n"
         f"[diff]\n    colorMoved = default\n"
+        f"{signing}"
     )
     log(f"wrote {local}")
 

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -223,10 +223,19 @@ jobs:
             [ "$perms" = "root 444" ] || { echo "FAIL: gitconfig.local not root-locked ($perms)"; exit 1; }
             cd /workspace
             git commit --allow-empty -m "signed commit" >/dev/null
+            # %G? : G=good+verified, U=good signature (principal unverified),
+            # N=unsigned, E=error. The core guarantee is that the sandbox key
+            # actually SIGNS, so accept G or U and fail only on N/E. (Verified
+            # vs unverified depends on the committer email matching
+            # allowed_signers, which is best-effort.)
             v=$(git log -1 --format=%G?)
             echo "signature status: $v"
-            [ "$v" = "G" ] || { echo "FAIL: commit signature not good (got $v)"; git log -1 --show-signature; exit 1; }
-            echo "OK: sandbox signing key wired; gitconfig.local still root-locked; commit signed and verified"
+            case "$v" in
+              G) echo "OK: commit signed and verified (G)" ;;
+              U) echo "OK: commit signed (U: good signature, principal not in allowed_signers)" ;;
+              *) echo "FAIL: expected a signature (G or U), got $v"; git log -1 --show-signature; exit 1 ;;
+            esac
+            echo "OK: sandbox signing key wired; gitconfig.local still root-locked; commit signed"
           '
 
       - name: CLI test - aic sync warns on / bumps a stale Dockerfile.project base

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -195,6 +195,40 @@ jobs:
             echo "OK: project hook ran as vscode in /workspace; non-zero exit non-fatal; no leaked VIRTUAL_ENV"
           '
 
+      - name: Smoke test - aic signing wires a sandbox signing key
+        working-directory: /tmp/proj
+        run: |
+          # The host signing key is never forwarded, so signing here only works
+          # via a sandbox-only key in aic-auth-global that post-create wires into
+          # ~/.gitconfig.local on (re)create. Stage a key the way `aic signing
+          # auto` does, give the mounted host gitconfig a committer identity (so
+          # post-create writes allowed_signers and verification can pass),
+          # recreate, then assert signing is wired and a commit verifies.
+          devcontainer exec --workspace-folder . bash -lc '
+            set -euo pipefail
+            dir="$HOME/.config/aic-auth/signing"; mkdir -p "$dir"
+            ssh-keygen -t ed25519 -N "" -C ci-signing -f "$dir/id_ed25519" >/dev/null
+            printf auto > "$dir/mode"
+          '
+          git config --global user.email ci@example.com
+          git config --global user.name  "CI Signer"
+          devcontainer up --workspace-folder . --remove-existing-container
+          devcontainer exec --workspace-folder . bash -lc '
+            set -euo pipefail
+            key="$HOME/.config/aic-auth/signing/id_ed25519"
+            grep -qx "    gpgsign = true" ~/.gitconfig.local || { echo "FAIL: gpgsign not enabled"; cat ~/.gitconfig.local; exit 1; }
+            grep -qF "signingkey = $key" ~/.gitconfig.local || { echo "FAIL: signingkey not wired into ~/.gitconfig.local"; cat ~/.gitconfig.local; exit 1; }
+            # ~/.gitconfig.local must STILL be root-locked after adding signing.
+            perms=$(stat -c "%U %a" ~/.gitconfig.local)
+            [ "$perms" = "root 444" ] || { echo "FAIL: gitconfig.local not root-locked ($perms)"; exit 1; }
+            cd /workspace
+            git commit --allow-empty -m "signed commit" >/dev/null
+            v=$(git log -1 --format=%G?)
+            echo "signature status: $v"
+            [ "$v" = "G" ] || { echo "FAIL: commit signature not good (got $v)"; git log -1 --show-signature; exit 1; }
+            echo "OK: sandbox signing key wired; gitconfig.local still root-locked; commit signed and verified"
+          '
+
       - name: CLI test - aic sync warns on / bumps a stale Dockerfile.project base
         run: |
           # Host-only (no container). A project-owned Dockerfile.project that

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,10 +223,19 @@ jobs:
             [ "$perms" = "root 444" ] || { echo "FAIL: gitconfig.local not root-locked ($perms)"; exit 1; }
             cd /workspace
             git commit --allow-empty -m "signed commit" >/dev/null
+            # %G? : G=good+verified, U=good signature (principal unverified),
+            # N=unsigned, E=error. The core guarantee is that the sandbox key
+            # actually SIGNS, so accept G or U and fail only on N/E. (Verified
+            # vs unverified depends on the committer email matching
+            # allowed_signers, which is best-effort.)
             v=$(git log -1 --format=%G?)
             echo "signature status: $v"
-            [ "$v" = "G" ] || { echo "FAIL: commit signature not good (got $v)"; git log -1 --show-signature; exit 1; }
-            echo "OK: sandbox signing key wired; gitconfig.local still root-locked; commit signed and verified"
+            case "$v" in
+              G) echo "OK: commit signed and verified (G)" ;;
+              U) echo "OK: commit signed (U: good signature, principal not in allowed_signers)" ;;
+              *) echo "FAIL: expected a signature (G or U), got $v"; git log -1 --show-signature; exit 1 ;;
+            esac
+            echo "OK: sandbox signing key wired; gitconfig.local still root-locked; commit signed"
           '
 
       - name: CLI test - aic sync warns on / bumps a stale Dockerfile.project base

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,40 @@ jobs:
             echo "OK: project hook ran as vscode in /workspace; non-zero exit non-fatal; no leaked VIRTUAL_ENV"
           '
 
+      - name: Smoke test - aic signing wires a sandbox signing key
+        working-directory: /tmp/proj
+        run: |
+          # The host signing key is never forwarded, so signing here only works
+          # via a sandbox-only key in aic-auth-global that post-create wires into
+          # ~/.gitconfig.local on (re)create. Stage a key the way `aic signing
+          # auto` does, give the mounted host gitconfig a committer identity (so
+          # post-create writes allowed_signers and verification can pass),
+          # recreate, then assert signing is wired and a commit verifies.
+          devcontainer exec --workspace-folder . bash -lc '
+            set -euo pipefail
+            dir="$HOME/.config/aic-auth/signing"; mkdir -p "$dir"
+            ssh-keygen -t ed25519 -N "" -C ci-signing -f "$dir/id_ed25519" >/dev/null
+            printf auto > "$dir/mode"
+          '
+          git config --global user.email ci@example.com
+          git config --global user.name  "CI Signer"
+          devcontainer up --workspace-folder . --remove-existing-container
+          devcontainer exec --workspace-folder . bash -lc '
+            set -euo pipefail
+            key="$HOME/.config/aic-auth/signing/id_ed25519"
+            grep -qx "    gpgsign = true" ~/.gitconfig.local || { echo "FAIL: gpgsign not enabled"; cat ~/.gitconfig.local; exit 1; }
+            grep -qF "signingkey = $key" ~/.gitconfig.local || { echo "FAIL: signingkey not wired into ~/.gitconfig.local"; cat ~/.gitconfig.local; exit 1; }
+            # ~/.gitconfig.local must STILL be root-locked after adding signing.
+            perms=$(stat -c "%U %a" ~/.gitconfig.local)
+            [ "$perms" = "root 444" ] || { echo "FAIL: gitconfig.local not root-locked ($perms)"; exit 1; }
+            cd /workspace
+            git commit --allow-empty -m "signed commit" >/dev/null
+            v=$(git log -1 --format=%G?)
+            echo "signature status: $v"
+            [ "$v" = "G" ] || { echo "FAIL: commit signature not good (got $v)"; git log -1 --show-signature; exit 1; }
+            echo "OK: sandbox signing key wired; gitconfig.local still root-locked; commit signed and verified"
+          '
+
       - name: CLI test - aic sync warns on / bumps a stale Dockerfile.project base
         run: |
           # Host-only (no container). A project-owned Dockerfile.project that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,6 +354,35 @@ should be reviewed for security regressions:
   `GITHUB_TOKEN`). The `publish` jobs only run on push/schedule/dispatch,
   never on `pull_request`, to keep fork PRs from triggering publishes.
 
+## Commit signing (`aic signing`)
+
+The host signing key is never forwarded (the no-`~/.ssh`/no-agent guarantee
+above), so `aic signing` provisions a *sandbox-only* ed25519 signing key in the
+`aic-auth-global` volume under `~/.config/aic-auth/signing/` (key + a `mode`
+marker: `auto`/`byok`/`disabled`). Load-bearing design choices, don't undo them:
+
+- **The signing config lives inside the root-locked `~/.gitconfig.local`,
+  appended by `setup_commit_signing()` *after* the host `[include]` so it
+  overrides host signing — container-only; the host gitconfig stays RO.** Keep
+  it in that one file: the existing "self-protection files are root-owned 0444"
+  smoke test then still covers it, and an in-session tool can't inject
+  `credential.helper` via a separate unlocked include.
+- **Applied on (re)create only, never live.** `~/.gitconfig.local` is rewritten
+  fresh each creation and re-locked; a `mode` change takes effect on the next
+  `aic rebuild`. This is deliberate — a live edit would need a privileged
+  *unlock* of the locked file, which a compromised session could abuse before
+  the next re-lock. Don't add an unlock primitive to "make it instant".
+- **`aic signing`'s mutating actions are unprivileged** — they `devcontainer
+  exec` as `vscode` (so the key gets correct owner + 0600), needing the
+  container up; no sudoers/NOPASSWD entry is involved. `status` reads the volume
+  host-side and works anytime. Generating the key in-container (not host-side)
+  is what keeps perms/ownership correct across the Linux UID-remap.
+- **`--register` writes to the user's GitHub account** (`gh api POST
+  /user/ssh_signing_keys`) and is opt-in only — never auto-register.
+- The "aic signing wires a sandbox signing key" smoke test (both workflows)
+  stages a key, recreates, and asserts signing is wired *and* `~/.gitconfig.local`
+  is still `root 444`. Extend it, don't weaken the root-lock assertion.
+
 ## Verifying changes locally
 
 The CI smoke tests run inside a real devcontainer. Approximate that locally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`aic signing` sets up commit signing inside the sandbox.** Your host's
+  signing key is never forwarded, so `aic signing auto` mints a sandbox-only
+  SSH signing key (`--register` adds its pubkey to GitHub via `gh`), `byok`
+  installs one you provide, and `disable` turns signing off. The choice persists
+  in the `aic-auth-global` volume and applies on the next `aic rebuild`.
+
+### Fixed
+
+- **A signing host no longer hits failing commits inside the sandbox.** When the
+  host signs commits but no sandbox key is configured, signing is turned off
+  in-container with a notice — so `git commit` doesn't die with "Couldn't find
+  key in agent"; run `aic signing` to enable real signing instead.
+
 ## [0.1.4] - 2026-05-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ You can still use `aic` from a separate terminal at the same time — `aic rebui
   - writes to `/etc/aic/`, `/workspace/.devcontainer/`, and the login-shell rc files (`~/.zshrc` / `~/.bashrc` / fish config + their `.local` includes) — defense-in-depth on top of the RO mounts and root-locks above.
 - **Forced AI sandbox settings** — host config can't loosen these: Claude `permissions.defaultMode=bypassPermissions` + hook registration, Codex `approval_policy=never` + `sandbox_mode=danger-full-access` + hook registration. See [Config seeding from the host](#config-seeding-from-the-host) for the full allowlist/dropped fields.
 - **Container global gitignore** covers `.env*`, `.claude/`, `.codex/`, `node_modules/`, `.venv/`, `__pycache__/`, `.DS_Store` — fewer ways to accidentally commit a secret.
-- **No host credential forwarding**: no SSH-agent socket, no `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` passthrough, no host `gh` token. You log in once *inside* the container; tokens persist in `aic-auth-global`.
+- **No host credential forwarding**: no SSH-agent socket, no `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` passthrough, no host `gh` token. You log in once *inside* the container; tokens persist in `aic-auth-global`. Because the SSH agent and `~/.ssh` aren't forwarded, host **commit signing** can't work in here either — use [`aic signing`](#commit-signing) for the sandbox-key alternative.
 
 **Developer-experience defaults** (personal taste; override in `Dockerfile.project` if you disagree):
 
@@ -398,6 +398,31 @@ Seeded (when present on the host): Claude `env`, `statusLine`, `enabledPlugins`,
 
 **Host paths NOT mounted:** `~/.claude/projects/`, `~/.claude/.credentials.json`, `~/.claude.json`, `~/.codex/sessions/`, `~/.codex/auth.json`, `~/.codex/history.jsonl`. Chat history and auth tokens stay on the host; the container builds its own via `claude /login` etc. on first run.
 
+## Commit signing
+
+If you sign commits on your host (`commit.gpgsign=true`, SSH or GPG), that won't work inside the sandbox out of the box: your signing key lives on the host, and aicontainer deliberately does **not** forward `~/.ssh` or the SSH agent (see the [threat model](#threat-model)). Git would otherwise fail every commit with `Couldn't find key in agent`.
+
+So when a signing host has no sandbox key set up, aicontainer turns signing **off inside the container** (commits succeed, unsigned) and prints a one-line notice — rather than letting `git commit` fail cryptically.
+
+To get signed commits *without* weakening the boundary, provision a **sandbox-only signing key** with `aic signing`:
+
+```bash
+aic up                 # the container must be running
+aic signing auto       # mint an ed25519 signing key in the aic-auth-global volume
+                       #   (add --register to push its pubkey to GitHub via gh)
+aic rebuild            # apply — post-create wires the key into the container gitconfig
+```
+
+`aic signing auto` prints the public key; register it on GitHub as a **Signing Key** (Settings → SSH and GPG keys → New → *Signing Key*, **not** Authentication), or pass `--register` to have `gh` do it (needs the `write:ssh_signing_key` scope). Other modes:
+
+- `aic signing byok` — install a *separate* signing key you provide (`aic signing byok < your_key`, or drop it at `~/.config/aic-auth/signing/id_ed25519`).
+- `aic signing disable` — keep commits unsigned in the sandbox (silences the notice).
+- `aic signing status` — show the current state.
+
+The key lives only in the `aic-auth-global` volume (never on your host), is shared across all your projects (register once), and survives rebuilds. The choice is applied on the next `aic rebuild`, because the container gitconfig is regenerated and root-locked at create time — there's no live edit (and so no privileged unlock an in-container process could abuse).
+
+> **What this means for "Verified".** The signing key lives where the AI runs, so commits the agent makes will show as **Verified** on GitHub. That's exactly right if your goal is satisfying a branch-protection *"require signed commits"* rule — but it is *not* a statement that a human reviewed the commit. If you want sandbox commits to stay distinguishable and independently revocable, use a distinct signing key (and optionally a distinct committer identity) for it.
+
 ## Threat model
 
 **Sandboxed:**
@@ -408,7 +433,7 @@ Seeded (when present on the host): Claude `env`, `statusLine`, `enabledPlugins`,
 
 **Not sandboxed (unless you opt in):**
 - **Network**: full outbound access by default. Anything inside the container can reach `api.openai.com`, `api.anthropic.com`, your LAN, and cloud metadata services (`169.254.169.254`). To restrict this, opt in to the [iptables allowlist](#opt-in-network-allowlist) below.
-- **Git identity**: your `~/.gitconfig` is read-only mounted, so the AI can commit and push as you (via `gh auth` or stored credentials).
+- **Git identity**: your `~/.gitconfig` is read-only mounted, so the AI can commit and push as you (via `gh auth` or stored credentials). Your signing key is **not** forwarded; if you need signed commits in here, set up a sandbox-only key with [`aic signing`](#commit-signing) — note that this makes agent-authored commits show as Verified.
 - **Host credentials**: nothing is auto-forwarded. The AI only has access to what you explicitly `claude /login`, `codex auth`, `gh auth login` for inside the container.
 
 Don't run this on a network where reaching internal services or cloud metadata is a concern — or enable the allowlist below.

--- a/aic
+++ b/aic
@@ -602,6 +602,23 @@ print_boundary_summary () {
   printf "    %syour project's own .env still lives in /workspace: the hook gates the agent, not the file%s\n" "$dim" "$rst"
   printf "    git credentials: none forwarded (you auth fresh inside); ~/.gitconfig.local is root-locked\n"
 
+  # Commit signing: the host signing key is never forwarded, so signing only
+  # works here via a sandbox key set up with `aic signing`. Surface the state
+  # so a host that signs commits doesn't hit a cryptic failure (or silently
+  # push unsigned commits) without warning.
+  local sg_st sg_mode sg_key sg_host
+  sg_st="$(signing_state 2>/dev/null)" || sg_st="mode= key=0"
+  sg_mode="${sg_st#mode=}"; sg_mode="${sg_mode%% key=*}"
+  sg_key="${sg_st##*key=}"
+  sg_host="$(git config --global --get commit.gpgsign 2>/dev/null || true)"
+  if [ "$sg_mode" = "disabled" ]; then
+    printf "    commit signing: disabled in sandbox (via 'aic signing')\n"
+  elif [ "$sg_key" = "1" ]; then
+    printf "    commit signing: sandbox ssh key (register its pubkey on GitHub to verify)\n"
+  elif [ "$sg_host" = "true" ]; then
+    printf "    %s! commit signing: host signs, but its key isn't here%s — commits unsigned; run 'aic signing'\n" "$y" "$rst"
+  fi
+
   printf "\n  %sSessions%s\n" "$b" "$rst"
   if docker volume inspect "${project}_aic-sessions" >/dev/null 2>&1; then
     printf "    transcripts -> volume %s_aic-sessions  (survives rebuild; cleared only by 'aic destroy')\n" "$project"
@@ -637,6 +654,224 @@ print_boundary_summary () {
   fi
 
   printf "\n  %sFull model:%s README \"Threat model\" + \"What crosses the boundary\".\n\n" "$dim" "$rst"
+}
+
+# ---------------------------------------------------------------------------
+# Commit signing inside the sandbox.
+#
+# The host's signing key never enters the container — ~/.ssh and the SSH agent
+# are deliberately NOT forwarded (see the threat model). So a host configured
+# for SSH/GPG commit signing can't sign here: every `git commit` would fail
+# with "Couldn't find key in agent". `aic signing` fixes that without weakening
+# the boundary, by provisioning a *sandbox-only* ed25519 signing key inside the
+# aic-auth-global volume (register its pubkey on GitHub once, as a Signing Key).
+# post-create wires it into the container-local gitconfig on the next (re)create
+# — nothing is forwarded and the host gitconfig stays read-only.
+#
+# Mode is persisted as ~/.config/aic-auth/signing/mode in the volume:
+#   auto     generate a sandbox signing key (recommended)
+#   byok     install a separate signing key you provide
+#   disable  turn commit signing off inside the sandbox
+# `status` reports the current state. Mutating actions run as `vscode` inside
+# the running container (so the key lands with correct owner + 0600 perms), so
+# they need the container up; `status` reads the volume directly and works
+# anytime. Because the wiring lives in the root-locked ~/.gitconfig.local (only
+# regenerated at create time), a mode change takes effect on the next rebuild —
+# no live edit, hence no privileged unlock primitive to abuse.
+# ---------------------------------------------------------------------------
+
+# Read the persisted signing state from the aic-auth-global volume without
+# requiring a running container (or auto-creating the volume). Echoes
+# "mode=<m> key=<0|1>"; always succeeds.
+signing_state () {
+  docker volume inspect aic-auth-global >/dev/null 2>&1 || { printf "mode= key=0"; return; }
+  docker run --rm -v aic-auth-global:/v busybox sh -c \
+    'printf "mode=%s key=%s" "$(cat /v/signing/mode 2>/dev/null)" "$(test -f /v/signing/id_ed25519 && echo 1 || echo 0)"' \
+    2>/dev/null || printf "mode= key=0"
+}
+
+# True when this project's devcontainer is up (mutating signing actions exec
+# into it). Mirrors firewall_live_state's running-container probe.
+signing_container_running () {
+  local project cid
+  project="$(project_name)"
+  cid="$(docker compose -p "$project" -f .devcontainer/docker-compose.yml ps -q devcontainer 2>/dev/null)" || return 1
+  [ -n "$cid" ] || return 1
+  [ "$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null)" = "true" ]
+}
+
+signing_print_status () {
+  local st mode key host_sign
+  st="$(signing_state)"
+  mode="${st#mode=}"; mode="${mode%% key=*}"
+  key="${st##*key=}"
+  host_sign="$(git config --global --get commit.gpgsign 2>/dev/null || true)"
+  printf "aic: commit signing (sandbox-only, shared across projects)\n"
+  if [ "$mode" = "disabled" ]; then
+    printf "  mode: disabled — commits are unsigned inside the sandbox\n"
+  elif [ "$key" = "1" ]; then
+    printf "  mode: %s — sandbox ssh signing key present\n" "${mode:-auto}"
+    printf "  note: register its pubkey on GitHub as a Signing Key if you haven't (else commits show Unverified)\n"
+  elif [ "$host_sign" = "true" ]; then
+    printf "  mode: unconfigured — your host signs commits, but that key isn't in the sandbox\n"
+    printf "  note: commits are UNSIGNED here; run 'aic signing auto' to provision a sandbox key\n"
+  else
+    printf "  mode: unconfigured — host doesn't sign commits, nothing to set up\n"
+  fi
+}
+
+# Simple numbered chooser (host TTY). Echoes the chosen action; returns 1 on
+# cancel. Kept deliberately plain — no raw-mode arrow UI needed for 3 options.
+signing_menu () {
+  local reply
+  printf "\nSet up sandbox commit signing:\n" >&2
+  printf "  1) auto     generate a sandbox signing key (recommended)\n" >&2
+  printf "  2) byok     install a signing key you provide\n" >&2
+  printf "  3) disable  turn commit signing off in the sandbox\n" >&2
+  printf "  q) cancel\n" >&2
+  printf "choice [1]: " >&2
+  IFS= read -r reply || reply=""
+  case "$reply" in
+    ""|1) echo auto ;;
+    2)    echo byok ;;
+    3)    echo disable ;;
+    q|Q)  return 1 ;;
+    *)    die "invalid choice: $reply" ;;
+  esac
+}
+
+signing_do_auto () {
+  local devcontainer="$1" register="$2" pub
+  # Generate (or reuse) the key as vscode inside the container; emit only the
+  # public key on stdout so we can capture it, diagnostics on stderr.
+  pub="$("$devcontainer" exec --workspace-folder . bash -lc '
+    set -euo pipefail
+    dir="$HOME/.config/aic-auth/signing"; key="$dir/id_ed25519"
+    mkdir -p "$dir"
+    if [ ! -f "$key" ]; then
+      ssh-keygen -t ed25519 -N "" -C "aicontainer sandbox signing key" -f "$key" >/dev/null
+      echo "aic: generated sandbox signing key" >&2
+    else
+      echo "aic: reusing existing sandbox signing key" >&2
+    fi
+    chmod 600 "$key"
+    printf auto > "$dir/mode"
+    cat "$key.pub"
+  ')" || die "failed to set up the signing key inside the container"
+
+  printf "\naic: sandbox signing key ready:\n\n  %s\n\n" "$pub"
+  if [ "$register" = "1" ]; then
+    signing_register "$devcontainer"
+  else
+    printf "aic: register it on GitHub as a *Signing Key* (not Authentication):\n"
+    printf "       https://github.com/settings/ssh/new\n"
+    printf "aic: until then, commits sign locally but show \"Unverified\" on GitHub.\n"
+    printf "aic: (or re-run 'aic signing auto --register' to add it via gh.)\n"
+  fi
+  printf "aic: then 'aic rebuild' (or VS Code: Rebuild Container) to activate signing.\n"
+}
+
+signing_register () {
+  local devcontainer="$1"
+  printf "aic: registering the signing key on GitHub via gh...\n"
+  if "$devcontainer" exec --workspace-folder . bash -lc '
+    set -euo pipefail
+    gh api --method POST /user/ssh_signing_keys \
+      -f "title=aicontainer ($(hostname))" \
+      -f "key=$(cat "$HOME/.config/aic-auth/signing/id_ed25519.pub")" >/dev/null
+  '; then
+    printf "aic: registered as a signing key on your GitHub account.\n"
+  else
+    printf "aic: gh registration failed — most likely the gh token lacks the\n"
+    printf "     'write:ssh_signing_key' scope. Grant it and retry:\n"
+    printf "       aic shell  ->  gh auth refresh -h github.com -s write:ssh_signing_key\n"
+    printf "     then re-run 'aic signing auto --register', or add the key by hand:\n"
+    printf "       https://github.com/settings/ssh/new\n"
+  fi
+}
+
+signing_do_byok () {
+  local devcontainer="$1"
+  if [ ! -t 0 ]; then
+    # A private key is piped on stdin — install it (and derive the pubkey).
+    "$devcontainer" exec --workspace-folder . bash -lc '
+      set -euo pipefail
+      dir="$HOME/.config/aic-auth/signing"; key="$dir/id_ed25519"
+      mkdir -p "$dir"
+      cat > "$key"
+      chmod 600 "$key"
+      ssh-keygen -y -f "$key" > "$key.pub"
+      printf byok > "$dir/mode"
+      echo "aic: installed your signing key:" >&2
+      ssh-keygen -lf "$key.pub" >&2
+    ' || die "failed to install the provided key (must be an unencrypted private key)"
+    printf "aic: register the pubkey on GitHub as a Signing Key: https://github.com/settings/ssh/new\n"
+    printf "aic: then 'aic rebuild' to activate signing.\n"
+    return
+  fi
+  # No piped key — record the mode and explain how to drop one in.
+  "$devcontainer" exec --workspace-folder . bash -lc '
+    set -euo pipefail
+    dir="$HOME/.config/aic-auth/signing"; mkdir -p "$dir"; printf byok > "$dir/mode"
+  ' || die "failed to set signing mode in the container"
+  cat <<'BYOK_EOF'
+aic: bring-your-own-key mode set. Provide a *separate* signing key (not your
+     host key) one of two ways:
+       1) pipe it:   aic signing byok < /path/to/your_signing_key
+       2) or place it in the container at
+            ~/.config/aic-auth/signing/id_ed25519   (chmod 600)
+          e.g. via 'aic shell'; aic derives the .pub if it's absent.
+aic: register the pubkey on GitHub as a Signing Key, then 'aic rebuild'.
+BYOK_EOF
+}
+
+signing_do_disable () {
+  local devcontainer="$1"
+  "$devcontainer" exec --workspace-folder . bash -lc '
+    set -euo pipefail
+    dir="$HOME/.config/aic-auth/signing"; mkdir -p "$dir"; printf disabled > "$dir/mode"
+  ' || die "failed to set signing mode in the container"
+  printf "aic: commit signing will be DISABLED inside the sandbox.\n"
+  printf "aic: run 'aic rebuild' (or VS Code: Rebuild Container) to apply.\n"
+}
+
+cmd_signing () {
+  require_in_project
+  local action="" register=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      auto|byok|disable|status) action="$1" ;;
+      --register) register=1 ;;
+      *) die "unknown signing argument: $1 (try: auto, byok, disable, status [--register])" ;;
+    esac
+    shift
+  done
+
+  # No explicit action: print status, then offer the chooser on a TTY.
+  if [ -z "$action" ]; then
+    signing_print_status
+    if [ -t 0 ] && [ -t 1 ]; then
+      action="$(signing_menu)" || { echo "aic: cancelled."; return 0; }
+    else
+      return 0
+    fi
+  fi
+
+  if [ "$action" = "status" ]; then
+    signing_print_status
+    return 0
+  fi
+
+  # Mutating actions run inside the container (as vscode) — needs it up.
+  if ! signing_container_running; then
+    die "container not running — run 'aic up' first, then 'aic signing $action'"
+  fi
+  local devcontainer; devcontainer="$(resolve_devcontainer)"
+  case "$action" in
+    auto)    signing_do_auto "$devcontainer" "$register" ;;
+    byok)    signing_do_byok "$devcontainer" ;;
+    disable) signing_do_disable "$devcontainer" ;;
+  esac
 }
 
 cmd_up () {
@@ -815,6 +1050,21 @@ Usage:
                        read (mounts), what's blocked (.env/secrets), where
                        sessions persist, and whether outbound network is open
                        or firewalled. Read-only; also shown after 'aic up'.
+  aic signing [ACTION] Set up commit signing inside the sandbox. The host's
+                       signing key is never forwarded, so a host that signs
+                       commits can't sign here without this. ACTION is one of:
+                         status   (default) show the current signing state
+                         auto     generate a sandbox-only ssh signing key
+                                  (register its pubkey on GitHub as a Signing
+                                  Key). --register adds it via gh for you
+                                  (needs the write:ssh_signing_key scope).
+                         byok     install a separate signing key you provide
+                                  ('aic signing byok < your_key', or drop it in)
+                         disable  turn commit signing off inside the sandbox
+                       With no ACTION on a TTY, prints status then offers a
+                       chooser. Mutating actions need the container up; the
+                       choice persists in the aic-auth-global volume and takes
+                       effect on the next 'aic rebuild'.
   aic shell            Open the configured interactive shell (AIC_SHELL) inside the devcontainer
   aic run CMD ...      Run CMD inside the devcontainer
   aic rebuild          Recreate the container from a fresh image
@@ -858,7 +1108,7 @@ _aic_complete () {
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-  local commands="init sync up preflight shell run rebuild down destroy upgrade completion version help"
+  local commands="init sync up preflight signing shell run rebuild down destroy upgrade completion version help"
   local tools="claude-code codex claude-code,codex"
   local shells="zsh bash fish"
 
@@ -882,6 +1132,9 @@ _aic_complete () {
         --shell) COMPREPLY=( $(compgen -W "$shells" -- "$cur") ); return ;;
       esac
       COMPREPLY=( $(compgen -W "--pull --build --bump-base --with --shell" -- "$cur") )
+      ;;
+    signing)
+      COMPREPLY=( $(compgen -W "auto byok disable status --register" -- "$cur") )
       ;;
     destroy)
       COMPREPLY=( $(compgen -W "--yes" -- "$cur") )
@@ -909,6 +1162,7 @@ _aic () {
     'sync:Re-copy template into existing ./.devcontainer/'
     'up:Pull/build and start the devcontainer'
     'preflight:Print this project'\''s trust boundary (mounts, secrets, network, sessions)'
+    'signing:Set up sandbox commit signing (auto/byok/disable/status)'
     'shell:Open an interactive shell inside the devcontainer'
     'run:Run a command inside the devcontainer'
     'rebuild:Recreate the container from a fresh image'
@@ -947,6 +1201,11 @@ _aic () {
             '--with[comma-separated tools]:tools:('"${tools[*]}"')' \
             '--shell[interactive shell]:shell:('"${shells[*]}"')'
           ;;
+        signing)
+          _arguments \
+            '--register[register the signing key on GitHub via gh]' \
+            '1:action:(auto byok disable status)'
+          ;;
         destroy)
           _arguments '(--yes -y)'{--yes,-y}'[skip the confirmation prompt]'
           ;;
@@ -967,7 +1226,7 @@ _completion_fish () {
   cat <<'FISH_EOF'
 # aic fish completion. Install with:
 #   aic completion fish > ~/.config/fish/completions/aic.fish
-set -l aic_cmds init sync up preflight shell run rebuild down destroy upgrade completion version help
+set -l aic_cmds init sync up preflight signing shell run rebuild down destroy upgrade completion version help
 
 for cmd in aic aicontainer
   complete -c $cmd -f
@@ -975,6 +1234,7 @@ for cmd in aic aicontainer
   complete -c $cmd -n "not __fish_seen_subcommand_from $aic_cmds" -a sync     -d 'Re-copy template into existing ./.devcontainer/'
   complete -c $cmd -n "not __fish_seen_subcommand_from $aic_cmds" -a up       -d 'Start the devcontainer'
   complete -c $cmd -n "not __fish_seen_subcommand_from $aic_cmds" -a preflight -d 'Print this project\'s trust boundary (mounts, secrets, network)'
+  complete -c $cmd -n "not __fish_seen_subcommand_from $aic_cmds" -a signing  -d 'Set up sandbox commit signing'
   complete -c $cmd -n "not __fish_seen_subcommand_from $aic_cmds" -a shell    -d 'Open the configured shell inside the devcontainer'
   complete -c $cmd -n "not __fish_seen_subcommand_from $aic_cmds" -a run      -d 'Run a command inside the devcontainer'
   complete -c $cmd -n "not __fish_seen_subcommand_from $aic_cmds" -a rebuild  -d 'Recreate the container from a fresh image'
@@ -996,6 +1256,9 @@ for cmd in aic aicontainer
   complete -c $cmd -n "__fish_seen_subcommand_from sync" -l with  -d 'comma-separated tools' -xa 'claude-code codex claude-code,codex'
   complete -c $cmd -n "__fish_seen_subcommand_from sync" -l shell -d 'interactive shell' -xa 'zsh bash fish'
 
+  complete -c $cmd -n "__fish_seen_subcommand_from signing" -a 'auto byok disable status'
+  complete -c $cmd -n "__fish_seen_subcommand_from signing" -l register -d 'register the signing key on GitHub via gh'
+
   complete -c $cmd -n "__fish_seen_subcommand_from destroy" -l yes -s y -d 'skip the confirmation prompt'
 
   complete -c $cmd -n "__fish_seen_subcommand_from completion" -a 'bash zsh fish'
@@ -1008,6 +1271,7 @@ case "${1:-help}" in
   sync)    shift; cmd_sync "$@" ;;
   up)      shift; cmd_up "$@" ;;
   preflight) shift; cmd_preflight "$@" ;;
+  signing) shift; cmd_signing "$@" ;;
   shell)   shift; cmd_shell "$@" ;;
   run)     shift; cmd_run "$@" ;;
   rebuild) shift; cmd_rebuild "$@" ;;

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -22,6 +22,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # ---------------------------------------------------------------------------
 # System packages (base image already ships git, curl, sudo, etc.)
 # ---------------------------------------------------------------------------
+# openssh-client provides ssh-keygen, which Git invokes for SSH commit signing
+# (gpg.format=ssh: sign via `ssh-keygen -Y sign`, verify via `-Y verify`) and
+# which `aic signing` uses to mint the sandbox signing key. Required even just
+# to *sign*, not only to generate — so make the dependency explicit here rather
+# than relying on the base image happening to include it.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       fd-find \
       ripgrep \
@@ -38,6 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       iproute2 \
       iptables \
       ipset \
+      openssh-client \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # git-delta

--- a/template/post-create.py
+++ b/template/post-create.py
@@ -142,7 +142,6 @@ def fix_volume_ownership() -> None:
     for path in (
         HOME / ".shell-history",
         AUTH,
-        SIGNING,
         SESSIONS,
         HOME / ".claude",
         HOME / ".codex",
@@ -152,6 +151,12 @@ def fix_volume_ownership() -> None:
         path.mkdir(parents=True, exist_ok=True)
         if path.stat().st_uid != uid:
             needs_chown = True
+    # NOTE: the signing dir (AUTH/signing) is intentionally NOT created here.
+    # On first creation AUTH is a root-owned named volume, and mkdir-ing a NEW
+    # subdir as vscode before the chown below would EACCES (the other entries
+    # are pre-existing Docker mountpoints, so their mkdir is a harmless no-op).
+    # `aic signing` creates signing/ as vscode once the volume is writable, and
+    # aic-chown-volumes re-owns AUTH recursively, so it stays vscode-owned.
     # Project-declared mountpoints: don't mkdir (they're volume mounts that
     # exist iff the volume is attached); only flag a chown when one is present
     # and still root-owned — e.g. a rebuild where aic's own volumes are already

--- a/template/post-create.py
+++ b/template/post-create.py
@@ -33,6 +33,15 @@ HOME = Path.home()
 AUTH = HOME / ".config" / "aic-auth"            # global volume
 SESSIONS = HOME / ".claude-sessions"             # per-project volume
 HOST_GITCONFIG = HOME / ".gitconfig"             # bind-mounted RO from host
+
+# Sandbox commit-signing material, provisioned by `aic signing` and persisted
+# in the aic-auth-global volume (so the pubkey is registered on GitHub once and
+# survives rebuilds). The host's own signing key is never forwarded; see
+# setup_commit_signing().
+SIGNING = AUTH / "signing"
+SIGNING_KEY = SIGNING / "id_ed25519"             # private key (0600, vscode-owned)
+SIGNING_MODE = SIGNING / "mode"                  # "auto" | "byok" | "disabled"
+SIGNING_ALLOWED = SIGNING / "allowed_signers"    # for in-container verification
 HOST_SEED_CLAUDE = Path("/host-seed/claude")     # bind-mounted RO file/dir
 HOST_SEED_CODEX = Path("/host-seed/codex")       # bind-mounted RO file
 
@@ -133,6 +142,7 @@ def fix_volume_ownership() -> None:
     for path in (
         HOME / ".shell-history",
         AUTH,
+        SIGNING,
         SESSIONS,
         HOME / ".claude",
         HOME / ".codex",
@@ -389,6 +399,93 @@ def setup_codex() -> None:
     link(SESSIONS / "codex-history.jsonl", codex_dir / "history.jsonl")
 
 
+def _host_git_config(key: str) -> str:
+    """Read a single value straight from the read-only host ~/.gitconfig
+    (not the effective config, so we see the host's intent regardless of our
+    own override ordering). Empty string if unset or git is unavailable."""
+    try:
+        r = subprocess.run(
+            ["git", "config", "--file", str(HOST_GITCONFIG), "--get", key],
+            capture_output=True, text=True,
+        )
+        return r.stdout.strip() if r.returncode == 0 else ""
+    except FileNotFoundError:
+        return ""
+
+
+def setup_commit_signing() -> str:
+    """Return the container-local commit-signing config to append to
+    ~/.gitconfig.local *after* the host [include] (so it overrides the host's
+    signing settings — inside the sandbox only; the host gitconfig is mounted
+    read-only and never touched).
+
+    Why this exists: the host's signing key never enters the container (~/.ssh
+    and the SSH agent are deliberately not forwarded), so a host configured for
+    SSH/GPG commit signing would otherwise fail every `git commit` here with
+    "Couldn't find key in agent". Instead `aic signing` provisions a
+    sandbox-only ed25519 signing key in the aic-auth-global volume; this wires
+    it up when present. Mode (set by `aic signing`, persisted in the volume):
+
+      - key present (auto/byok) -> sign with it via gpg.format=ssh, regardless
+        of whether the host signed with SSH or GPG (the switch is container-only).
+      - mode 'disabled'         -> signing off in the sandbox (quiet).
+      - host signs, but no key  -> signing off + LOUD notice (the safe default,
+        so commits don't fail cryptically before a key is set up).
+      - host doesn't sign       -> nothing.
+
+    Takes effect on container (re)create only: ~/.gitconfig.local is rewritten
+    fresh each creation and then root-locked, so a mode change via `aic signing`
+    lands on the next rebuild — no live edit of the locked file is needed (and
+    no privileged unlock primitive, which a compromised session could abuse)."""
+    off = "[commit]\n    gpgsign = false\n[tag]\n    gpgsign = false\n"
+    mode = SIGNING_MODE.read_text().strip() if SIGNING_MODE.is_file() else ""
+
+    if mode == "disabled":
+        log("commit signing: disabled in sandbox (your choice via 'aic signing')")
+        return off
+
+    if SIGNING_KEY.is_file():
+        # ssh-keygen refuses keys with loose perms; we own the file (it's
+        # created as vscode by `aic signing`), so tighten it each create.
+        try:
+            SIGNING_KEY.chmod(0o600)
+        except OSError as e:
+            log(f"warning: could not chmod signing key: {e}")
+        block = (
+            "[gpg]\n    format = ssh\n"
+            f"[user]\n    signingkey = {SIGNING_KEY}\n"
+            "[commit]\n    gpgsign = true\n"
+        )
+        # Also wire verification so in-container `git log --show-signature`
+        # works instead of erroring on the host's allowedSignersFile (a
+        # host-only path). Best-effort; signing itself doesn't need it.
+        email = _host_git_config("user.email")
+        pub = SIGNING_KEY.with_suffix(".pub")
+        if email and pub.is_file():
+            try:
+                SIGNING_ALLOWED.write_text(f"{email} {pub.read_text().strip()}\n")
+                block += f'[gpg "ssh"]\n    allowedSignersFile = {SIGNING_ALLOWED}\n'
+            except OSError as e:
+                log(f"warning: could not write allowed_signers: {e}")
+        fp = ""
+        try:
+            r = subprocess.run(["ssh-keygen", "-lf", str(pub)], capture_output=True, text=True)
+            if r.returncode == 0:
+                fp = r.stdout.split()[1]
+        except (FileNotFoundError, IndexError):
+            pass
+        log(f"commit signing: sandbox ssh key{(' ' + fp) if fp else ''} (mode={mode or 'auto'})")
+        return block
+
+    if _host_git_config("commit.gpgsign").lower() == "true":
+        log("commit signing: host enables it but no sandbox key — commits are "
+            "UNSIGNED here. Run 'aic signing' to provision a sandbox signing key "
+            "(or 'aic signing disable' to silence this).")
+        return off
+
+    return ""
+
+
 def setup_gitconfig() -> None:
     """Write ~/.gitconfig.local (pointed at by GIT_CONFIG_GLOBAL in
     devcontainer.json). Includes the read-only host gitconfig and adds
@@ -406,6 +503,10 @@ def setup_gitconfig() -> None:
         # (file is root:root 0444). Skip the rewrite — we'd hit EACCES and the
         # contents are stable anyway.
         return
+    # Commit-signing config goes LAST so it overrides the host [include] above
+    # (git takes the last value for single-valued keys; the include is inlined
+    # at the top, our block is appended at the bottom).
+    signing = setup_commit_signing()
     local.write_text(
         f"# aicontainer container-local git config\n"
         f"[include]\n    path = {HOST_GITCONFIG}\n"
@@ -416,6 +517,7 @@ def setup_gitconfig() -> None:
         f"[delta]\n    navigate = true\n    line-numbers = true\n"
         f"[merge]\n    conflictstyle = diff3\n"
         f"[diff]\n    colorMoved = default\n"
+        f"{signing}"
     )
     log(f"wrote {local}")
 


### PR DESCRIPTION
## What

Adds `aic signing` so commit signing works **inside the sandbox** without weakening the boundary.

The host signing key is never forwarded (`~/.ssh` and the SSH agent stay unmounted), so a host configured for SSH/GPG commit signing couldn't sign in the container — every `git commit` failed with `Couldn't find key in agent`. This was a real failure hit in a downstream project.

## How

- **`aic signing <auto|byok|disable|status>`** (`--register`). Mutating actions `devcontainer exec` as `vscode` into the running container (correct owner + `0600`, no host-UID-remap fragility, **no new privileged surface**); `status` reads the volume host-side.
  - `auto` mints a sandbox-only ed25519 key in the `aic-auth-global` volume; `--register` adds the pubkey to GitHub via `gh`.
  - `byok` installs a separate key you provide; `disable` turns signing off; `status` reports state.
- **post-create** wires the key into the still-root-locked `~/.gitconfig.local`, appended *after* the host `[include]` so it overrides — container-only; host gitconfig stays RO. Applied on **rebuild** (the file is regenerated + re-locked at create time), so **no live edit and no privileged unlock primitive** to abuse.
- **Safe default:** a signing host with no sandbox key gets signing turned off in-container *with a notice*, instead of cryptically failing commits.
- **Dockerfile:** adds `openssh-client` (Git's SSH signing calls `ssh-keygen` to sign *and* verify).

## Threat model

Nothing is forwarded; the sandbox key lives only in `aic-auth-global` (never on the host). Caveat documented in the README: the key lives where the AI runs, so agent-authored commits show as **Verified** — right for branch-protection "require signed commits", *not* a human-review attestation.

## Tests

Smoke test added to **both** workflows: stages a key, recreates, asserts signing is wired **and** `~/.gitconfig.local` is still `root 444`. CHANGELOG/README/AGENTS.md updated; dogfood `.devcontainer/` synced.