### PR TITLE
ci(renovate): keep ARG *_VERSION bumps in sync with .devcontainer/Dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,9 @@
   ],
   "customManagers": [
     {
+      "description": "Keep the ARG *_VERSION pins in sync across both Dockerfiles. .devcontainer/Dockerfile is a build-mode copy of template/Dockerfile; the built-in dockerfile manager already bumps FROM digests in both, so scope this regex manager to both too — otherwise fzf/git-delta bumps land only in template/ and the dogfood drifts every cycle (reconciled previously by a manual `aic sync`).",
       "customType": "regex",
-      "managerFilePatterns": ["/^template/Dockerfile$/"],
+      "managerFilePatterns": ["/^template/Dockerfile$/", "/^\\.devcontainer/Dockerfile$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)(?: registryUrl=(?<registryUrl>.*?))?\\s+ARG \\w+_VERSION=(?<currentValue>.*)\\s"
       ]


### PR DESCRIPTION
## Problem

The regex `customManager` in `renovate.json` that bumps `ARG *_VERSION` pins (fzf, git-delta) was scoped to **`template/Dockerfile` only**:

```json
"managerFilePatterns": ["/^template/Dockerfile$/"]
```

Meanwhile the **built-in `dockerfile` manager** (FROM-line digests) is *not* file-scoped, so it updates both `template/Dockerfile` **and** the build-mode dogfood copy `.devcontainer/Dockerfile`.

That asymmetry means:
- FROM-digest bumps (uv, base image) → land in **both** files (e.g. #7, #10). ✅
- `ARG *_VERSION` bumps (fzf, git-delta) → land in **template/ only** (#8, #9), so `.devcontainer/Dockerfile` silently drifts **every cycle** and needs a manual `aic sync` to reconcile.

This just bit the v0.3.1 release: #8/#9 drifted the dogfood and I had to `aic sync` before cutting it.

## Fix

Scope the `customManager` to **both** Dockerfiles so the two managers are symmetric and Renovate keeps them in sync directly:

```json
"managerFilePatterns": ["/^template/Dockerfile$/", "/^\\.devcontainer/Dockerfile$/"]
```

Result: dep bumps no longer drift the dogfood — `aic sync` is only needed for real `template/` changes (feature work), not routine Renovate PRs.

## Alternative considered (rejected)

Make Renovate **ignore** `.devcontainer/` entirely (treat it as a pure generated artifact, always reconciled by `aic sync`). Rejected because it would make **every** Renovate cycle — including FROM-digest bumps that currently stay in sync — require a manual `aic sync`, *increasing* toil and drift rather than eliminating it. Keeping both managers symmetric is the lower-friction choice and matches the existing FROM-line behavior.

## Validation

- `renovate-config-validator` (renovate@41): **Config validated successfully**.
- File-pattern check: matches `template/Dockerfile` and `.devcontainer/Dockerfile`; the `$` anchor correctly **excludes** project-owned `Dockerfile.project` (and its path variants).
- Added an inline `description` (a supported `customManagers` field) documenting why both files are listed, so this scoping isn't re-narrowed by accident.

## No CHANGELOG entry

Repo-internal CI/automation config — `renovate.json` is not shipped to users and changes no `template/` behavior or `aic` CLI surface, so it's not user-facing per AGENTS.md's changelog rule.